### PR TITLE
Added controller tests, fixed fixture typo

### DIFF
--- a/test/controllers/store_controller_test.rb
+++ b/test/controllers/store_controller_test.rb
@@ -6,6 +6,12 @@ class StoreControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
     get store_index_url
     assert_response :success
+    assert_select "nav.side_nav a", minimum: 4
+    # selectors that start with `.` are class attributes
+    # selectors that start with `#` are id attributes
+    assert_select "main ul.catalog li", 3
+    assert_select "h2", "Programming Ruby 1.9"
+    assert_select ".price", /\$[,\d]+\.\d\d/
   end
 
 end

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -13,7 +13,7 @@ two:
   price: 9.99
 
 ruby:
-  title: Proogramming Ruby 1.9
+  title: Programming Ruby 1.9
   description:
     Ruby is the fastest growing and most exciting dynamic
     language out there. If you need to get working programs


### PR DESCRIPTION
## Story:
Added controller tests


## Changes:
  - added `assert_select` statements to look at specific html/css tags to find content expected
  - subtracted superfluous `o` from `Programming Ruby 1.9`

## Lessons Learned: 
  - `assert_select` looks through the tags provided, if it doesn't find what it's looking for, when it errors, it returns what seems like any old random result to show the failure, possibly it was returning the second fixture because it couldn't find the title it was looking for due to the typo ini the third fixture.  This was annoying to track down.  It should be populating the `ul` alphabetically, so I really don't know why it kept stopping at `MyString`
- as a reminder:
  - `#` = css id attributes
  - `.` = css class attributes

## Resources:
[Iteration C4: Functional Testing of Controllers](https://learning.oreilly.com/library/view/agile-web-development/9781680507522/f_0054.xhtml)

## Screenshots: 

![image](https://user-images.githubusercontent.com/41622204/99593444-93e04780-29e9-11eb-8ea7-1641acb7ccf4.png)

I think the line: `Expected 0 to be >= 1.` is basically 'expected to find one of the title `Programming Ruby 1.9` but found none.'

confirmed:
![image](https://user-images.githubusercontent.com/41622204/99593743-0fda8f80-29ea-11eb-9492-cf5c7a350686.png)

![image](https://user-images.githubusercontent.com/41622204/99593736-0c470880-29ea-11eb-98b7-d388eac99efe.png)
