### PR TITLE
C5: Caching of Partial Results

### DIFF
--- a/app/views/store/index.html.erb
+++ b/app/views/store/index.html.erb
@@ -5,16 +5,20 @@
 <h1>Your Pragmatic Catalog</h1>
 
 <ul class="catalog">
-  <% @products.each do |product| %>
-    <li>
-      <%= image_tag(product.image_url) %>
-      <h2><%= product.title %></h2>
-      <p>
-        <%= sanitize(product.description) %>
-      </p>
-      <div class="price">
-        <%= number_to_currency(product.price) %>
-      </div>
-    </li>
+  <% cache @products do %> 
+    <% @products.each do |product| %>
+      <% cache product do %>
+        <li>
+          <%= image_tag(product.image_url) %>
+          <h2><%= product.title %></h2>
+          <p>
+            <%= sanitize(product.description) %>
+          </p>
+          <div class="price">
+            <%= number_to_currency(product.price) %>
+          </div>
+        </li>
+      <% end %>
+    <% end %>
   <% end %>
 </ul>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,6 +18,7 @@ Rails.application.configure do
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
+    # toggling this toggles verbose logging
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store


### PR DESCRIPTION
## Story: 
Cache the products list, and individual products to speed up page load.

## Changes:
  - added two levels of caching to the `store/index.html.erb` file

## Lessons Learned: 
  - in the dev environment you can toggle caching on and off with: `bin/rails dev:cache`

## Resources:
[Iteration C5: Caching of Partial Results](https://learning.oreilly.com/library/view/agile-web-development/9781680507522/f_0055.xhtml)
[Caching with Rails: An Overview](https://guides.rubyonrails.org/caching_with_rails.html)
[Number Helper - Rails Docs](https://api.rubyonrails.org/classes/ActionView/Helpers/NumberHelper.html)
