### PR TITLE
D2 connecting products to carts

### DIFF
--- a/app/assets/stylesheets/line_items.scss
+++ b/app/assets/stylesheets/line_items.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the LineItems controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class LineItemsController < ApplicationController
+  before_action :set_line_item, only: [:show, :edit, :update, :destroy]
+
+  # GET /line_items
+  # GET /line_items.json
+  def index
+    @line_items = LineItem.all
+  end
+
+  # GET /line_items/1
+  # GET /line_items/1.json
+  def show
+  end
+
+  # GET /line_items/new
+  def new
+    @line_item = LineItem.new
+  end
+
+  # GET /line_items/1/edit
+  def edit
+  end
+
+  # POST /line_items
+  # POST /line_items.json
+  def create
+    @line_item = LineItem.new(line_item_params)
+
+    respond_to do |format|
+      if @line_item.save
+        format.html { redirect_to @line_item, notice: "Line item was successfully created." }
+        format.json { render :show, status: :created, location: @line_item }
+      else
+        format.html { render :new }
+        format.json { render json: @line_item.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /line_items/1
+  # PATCH/PUT /line_items/1.json
+  def update
+    respond_to do |format|
+      if @line_item.update(line_item_params)
+        format.html { redirect_to @line_item, notice: "Line item was successfully updated." }
+        format.json { render :show, status: :ok, location: @line_item }
+      else
+        format.html { render :edit }
+        format.json { render json: @line_item.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /line_items/1
+  # DELETE /line_items/1.json
+  def destroy
+    @line_item.destroy
+    respond_to do |format|
+      format.html { redirect_to line_items_url, notice: "Line item was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+  def set_line_item
+    @line_item = LineItem.find(params[:id])
+  end
+
+    # Only allow a list of trusted parameters through.
+  def line_item_params
+    params.require(:line_item).permit(:product_id, :cart_id)
+  end
+end

--- a/app/helpers/line_items_helper.rb
+++ b/app/helpers/line_items_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module LineItemsHelper
+end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Cart < ApplicationRecord
+  has_many :line_items, dependent: :destroy
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class LineItem < ApplicationRecord
+  belongs_to :product
+  belongs_to :cart
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -10,4 +10,18 @@ class Product < ApplicationRecord
     with: /\.(gif|jpg|png)\z/i,
     message: "must be a URL for GIF, JPG or PNG image."
   }
+
+  has_many :line_items
+
+  before_destroy :ensure_not_referenced_by_any_line_item
+
+  private
+
+  # ensure that there are no line items referencing this product
+  def ensure_not_referenced_by_any_line_item
+    unless line_items.empty?
+      errors.add(:base, "Line Items present")
+      throw :abort
+    end
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,7 +11,7 @@ class Product < ApplicationRecord
     message: "must be a URL for GIF, JPG or PNG image."
   }
 
-  has_many :line_items
+  has_many :line_items, dependent: :restrict_with_error
 
   before_destroy :ensure_not_referenced_by_any_line_item
 

--- a/app/views/line_items/_form.html.erb
+++ b/app/views/line_items/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: line_item, local: true) do |form| %>
+  <% if line_item.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(line_item.errors.count, "error") %> prohibited this line_item from being saved:</h2>
+
+      <ul>
+        <% line_item.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :product_id %>
+    <%= form.text_field :product_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :cart_id %>
+    <%= form.text_field :cart_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/line_items/_line_item.json.jbuilder
+++ b/app/views/line_items/_line_item.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.extract! line_item, :id, :product_id, :cart_id, :created_at, :updated_at
+json.url line_item_url(line_item, format: :json)

--- a/app/views/line_items/edit.html.erb
+++ b/app/views/line_items/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Line Item</h1>
+
+<%= render 'form', line_item: @line_item %>
+
+<%= link_to 'Show', @line_item %> |
+<%= link_to 'Back', line_items_path %>

--- a/app/views/line_items/index.html.erb
+++ b/app/views/line_items/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Line Items</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Product</th>
+      <th>Cart</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @line_items.each do |line_item| %>
+      <tr>
+        <td><%= line_item.product_id %></td>
+        <td><%= line_item.cart_id %></td>
+        <td><%= link_to 'Show', line_item %></td>
+        <td><%= link_to 'Edit', edit_line_item_path(line_item) %></td>
+        <td><%= link_to 'Destroy', line_item, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Line Item', new_line_item_path %>

--- a/app/views/line_items/index.json.jbuilder
+++ b/app/views/line_items/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @line_items, partial: "line_items/line_item", as: :line_item

--- a/app/views/line_items/new.html.erb
+++ b/app/views/line_items/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Line Item</h1>
+
+<%= render 'form', line_item: @line_item %>
+
+<%= link_to 'Back', line_items_path %>

--- a/app/views/line_items/show.html.erb
+++ b/app/views/line_items/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Product:</strong>
+  <%= @line_item.product_id %>
+</p>
+
+<p>
+  <strong>Cart:</strong>
+  <%= @line_item.cart_id %>
+</p>
+
+<%= link_to 'Edit', edit_line_item_path(@line_item) %> |
+<%= link_to 'Back', line_items_path %>

--- a/app/views/line_items/show.json.jbuilder
+++ b/app/views/line_items/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "line_items/line_item", line_item: @line_item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :line_items
   resources :carts
   # as 'store_index' means we can use 'store_index_path' and 'store_index_url'
   root "store#index", as: "store_index"

--- a/db/migrate/20201120163254_create_line_items.rb
+++ b/db/migrate/20201120163254_create_line_items.rb
@@ -1,0 +1,10 @@
+class CreateLineItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :line_items do |t|
+      t.references :product, null: false, foreign_key: true
+      t.belongs_to :cart, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_092806) do
+ActiveRecord::Schema.define(version: 2020_11_20_163254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,15 @@ ActiveRecord::Schema.define(version: 2020_11_20_092806) do
   create_table "carts", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "line_items", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.bigint "cart_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cart_id"], name: "index_line_items_on_cart_id"
+    t.index ["product_id"], name: "index_line_items_on_product_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -29,4 +38,6 @@ ActiveRecord::Schema.define(version: 2020_11_20_092806) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "line_items", "carts"
+  add_foreign_key "line_items", "products"
 end

--- a/test/controllers/line_items_controller_test.rb
+++ b/test/controllers/line_items_controller_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LineItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @line_item = line_items(:one)
+  end
+
+  test "should get index" do
+    get line_items_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_line_item_url
+    assert_response :success
+  end
+
+  test "should create line_item" do
+    assert_difference("LineItem.count") do
+      post line_items_url, params: {
+        line_item: {
+          cart_id: @line_item.cart_id,
+          product_id: @line_item.product_id
+        }
+      }
+    end
+
+    assert_redirected_to line_item_url(LineItem.last)
+  end
+
+  test "should show line_item" do
+    get line_item_url(@line_item)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_line_item_url(@line_item)
+    assert_response :success
+  end
+
+  test "should update line_item" do
+    patch line_item_url(@line_item), params: {
+      line_item: {
+        cart_id: @line_item.cart_id,
+        product_id: @line_item.product_id
+      }
+    }
+    assert_redirected_to line_item_url(@line_item)
+  end
+
+  test "should destroy line_item" do
+    assert_difference("LineItem.count", -1) do
+      delete line_item_url(@line_item)
+    end
+
+    assert_redirected_to line_items_url
+  end
+end

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -55,6 +55,14 @@ class ProductsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to product_url(@product)
   end
 
+  test "can't delete product in cart" do
+    assert_difference("Product.count", 0) do
+      delete product_url(products(:two))
+    end
+
+    assert_redirected_to products_url
+  end
+
   test "should destroy product" do
     assert_difference("Product.count", -1) do
       delete product_url(@product)

--- a/test/fixtures/line_items.yml
+++ b/test/fixtures/line_items.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  product: one
+  cart: one
+
+two:
+  product: two
+  cart: two

--- a/test/fixtures/line_items.yml
+++ b/test/fixtures/line_items.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  product: one
+  product: two
   cart: one
 
 two:

--- a/test/models/line_item_test.rb
+++ b/test/models/line_item_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LineItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/line_items_test.rb
+++ b/test/system/line_items_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class LineItemsTest < ApplicationSystemTestCase
+  setup do
+    @line_item = line_items(:one)
+  end
+
+  test "visiting the index" do
+    visit line_items_url
+    assert_selector "h1", text: "Line Items"
+  end
+
+  test "creating a Line item" do
+    visit line_items_url
+    click_on "New Line Item"
+
+    fill_in "Cart", with: @line_item.cart_id
+    fill_in "Product", with: @line_item.product_id
+    click_on "Create Line item"
+
+    assert_text "Line item was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Line item" do
+    visit line_items_url
+    click_on "Edit", match: :first
+
+    fill_in "Cart", with: @line_item.cart_id
+    fill_in "Product", with: @line_item.product_id
+    click_on "Update Line item"
+
+    assert_text "Line item was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Line item" do
+    visit line_items_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Line item was successfully destroyed"
+  end
+end


### PR DESCRIPTION
## Story:
create line item with associations, create hook method to prevent products from being deleted if they're in a line item. 

## Changes:
  - `bin/rails generate scaffold LineItem product:references cart:belongs_to` - both come up as `belongs_to`
  - added `has_many` to both other models
  - added a `before_destroy` method to `Product` to keep products from deleting if they are in a line item.
  - edited `line_items.yml`to put product `two` in `line_item` `one`.  This is so that  product `two` could never be deleted in tests, but product `one` could be deleted.

## Lessons Learned: 
  - Handy note:
    - `line_item` `belongs_to` both `product` and `cart`
    - each in turn `has_many` `line_items`
    - from a `line_item` object you can access a `product` or a `cart`and it's attributes:
      - `line_item.product.title`
      - `line_item.cart.id`
    - from a `cart` you can get to the `line_items`:
      - `cart.line_items.count`
      - `cart.line_items.map(&:id)`
     - I'd like to pop open a console and play with getting from a `product` to `line_items` and from there to a `cart`

## Resources:
[Iteration D2: Connecting Products to Carts
](https://learning.oreilly.com/library/view/agile-web-development/9781680507522/f_0059.xhtml)
[4.3.2 Options for has_many](https://guides.rubyonrails.org/association_basics.html#has-many-association-reference)

## Screenshots: 
[If you made some visual changes to the application please upload screenshots here, or remove this section]