### PR TITLE
D3 adding button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -80,5 +80,15 @@ body {
     main {
       padding: 0.5em;
     }
+    .notice, #notice{
+      background: #ffb;
+      border-radiu: 0.5em;
+      border: solid 0.177em #882;
+      color: #882;
+      font-weight: bold;
+      margin-bottom: 1em;
+      padding: 1em 1.414em;
+      text-align: center;
+    }
   }
   //

--- a/app/assets/stylesheets/store.scss
+++ b/app/assets/stylesheets/store.scss
@@ -43,6 +43,9 @@
           font-size: 1em;
           padding: 0.354em 1em;
         }
+        input[type="submit"]:hover{
+          background-color: #141;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/store.scss
+++ b/app/assets/stylesheets/store.scss
@@ -31,6 +31,18 @@
         .price {
           font-size: 1.414em;
         }
+
+        form, div {
+          display: inline;
+        }
+        input[type="submit"]{
+          background-color: #282;
+          border-radius: 0.354em;
+          border: solid thin #141;
+          color: white;
+          font-size: 1em;
+          padding: 0.354em 1em;
+        }
       }
     }
   }

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -2,7 +2,6 @@
 
 class LineItemsController < ApplicationController
   include CurrentCart
-  before_action :set_cart, only: [:create]
   before_action :set_line_item, only: [:show, :edit, :update, :destroy]
 
   # GET /line_items
@@ -28,6 +27,7 @@ class LineItemsController < ApplicationController
   # POST /line_items
   # POST /line_items.json
   def create
+    set_cart
     product = Product.find(params[:product_id])
     @line_item = @cart.line_items.build(product: product)
 

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LineItemsController < ApplicationController
+  include CurrentCart
+  before_action :set_cart, only: [:create]
   before_action :set_line_item, only: [:show, :edit, :update, :destroy]
 
   # GET /line_items
@@ -26,12 +28,15 @@ class LineItemsController < ApplicationController
   # POST /line_items
   # POST /line_items.json
   def create
-    @line_item = LineItem.new(line_item_params)
+    product = Product.find(params[:product_id])
+    @line_item = @cart.line_items.build(product: product)
 
     respond_to do |format|
       if @line_item.save
-        format.html { redirect_to @line_item, notice: "Line item was successfully created." }
-        format.json { render :show, status: :created, location: @line_item }
+        format.html { redirect_to @line_item.cart,
+          notice: "Line item was successfully created." }
+        format.json { render :show,
+          status: :created, location: @line_item }
       else
         format.html { render :new }
         format.json { render json: @line_item.errors, status: :unprocessable_entity }

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -33,10 +33,14 @@ class LineItemsController < ApplicationController
 
     respond_to do |format|
       if @line_item.save
-        format.html { redirect_to @line_item.cart,
-          notice: "Line item was successfully created." }
-        format.json { render :show,
-          status: :created, location: @line_item }
+        format.html {
+          redirect_to @line_item.cart,
+          notice: "Line item was successfully created."
+        }
+        format.json {
+          render :show,
+          status: :created, location: @line_item
+        }
       else
         format.html { render :new }
         format.json { render json: @line_item.errors, status: :unprocessable_entity }

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -1,4 +1,13 @@
-<p id="notice"><%= notice %></p>
+<% if notice %>
+  <aside id="notice"><%= notice %></aside>
+<% end %> 
+
+<h2>Your Pragmatic Cart</h2>
+<ul>
+  <% @cart.line_items.each do |item| %>
+    <li><%= item.product.title %></li>
+  <% end %>
+</ul>   
 
 <%= link_to 'Edit', edit_cart_path(@cart) %> |
 <%= link_to 'Back', carts_path %>

--- a/app/views/store/index.html.erb
+++ b/app/views/store/index.html.erb
@@ -16,6 +16,7 @@
           </p>
           <div class="price">
             <%= number_to_currency(product.price) %>
+            <%= button_to "Add to Cart", line_items_path(product_id: product) %> 
           </div>
         </li>
       <% end %>

--- a/test/controllers/line_items_controller_test.rb
+++ b/test/controllers/line_items_controller_test.rb
@@ -19,15 +19,13 @@ class LineItemsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create line_item" do
     assert_difference("LineItem.count") do
-      post line_items_url, params: {
-        line_item: {
-          cart_id: @line_item.cart_id,
-          product_id: @line_item.product_id
-        }
-      }
+      post line_items_url, params: { product_id: products(:ruby).id }
     end
 
-    assert_redirected_to line_item_url(LineItem.last)
+    follow_redirect!
+
+    assert_select "h2", "Your Pragmatic Cart"
+    assert_select "li", "Programming Ruby 1.9"
   end
 
   test "should show line_item" do


### PR DESCRIPTION
## Story:
Added an 'Add to Cart' button, which creates a line item in the session cart, show the user the cart. 

## Changes:
  - Add `Add to Cart` button to `store/index.html.erb`
  - Update`store.scss` to add button styling.
  - call `set_cart` from the `CurrentCart` module in `line_items_controller` `create` action which will find the shopping cart for the current session - or create one
  - add code to build the new line item in the `create` action of the `line_items_controller`
  - created very basic `carts/show.html.erb` template file
  - added styling to `applications.scss` for styling notices
  - updated appropriate test

## Lessons Learned: 
  - Good reminder: links - are GET requests, forms make POST requests - so we use buttons.
    - From `button_to` ruby docs: "If no :method modifier is given, it will default to performing a POST operation."
  - `button_to` - similiar to `link_to`
  - While the `line_items_path` just needs the `product_id` to create the line item, if the `product` is passed in, rails is smart enough to just take the `id` from it.
  - used callback `before_action` (note: I removed it because `set_cart` was only being used for `create` - so I just called it in the first line of create)

## Notes
  - The playtime section in this iteration looks interesting:
    - add a counter that tracks how many times thee user goes to the store controllers index action and variations. Worth looking at.

## Resources:
[Iteration D3: Adding a Button](https://learning.oreilly.com/library/view/agile-web-development/9781680507522/f_0060.xhtml)
[button_to in Rails docs](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-button_to)

## Screenshots: 
![image](https://user-images.githubusercontent.com/41622204/99919078-13845400-2d13-11eb-938f-e90e43cf161a.png)
