### PR TITLE
E1 smarter cart

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -29,7 +29,7 @@ class LineItemsController < ApplicationController
   def create
     set_cart
     product = Product.find(params[:product_id])
-    @line_item = @cart.line_items.build(product: product)
+    @line_item = @cart.add_product(product)
 
     respond_to do |format|
       if @line_item.save

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -2,4 +2,14 @@
 
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
+
+  def add_product(product)
+    current_item = line_items.find_by(product_id: product.id)
+    if current_item
+      current_item.quantity += 1
+    else
+      current_item = line_items.build(product_id: product.id)
+    end
+    current_item
+  end
 end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -5,7 +5,7 @@
 <h2>Your Pragmatic Cart</h2>
 <ul>
   <% @cart.line_items.each do |item| %>
-    <li><%= item.product.title %></li>
+    <li><%= item.quantity %> &times; <%= item.product.title %></li>
   <% end %>
 </ul>   
 

--- a/db/migrate/20201122224833_add_quantity_to_line_items.rb
+++ b/db/migrate/20201122224833_add_quantity_to_line_items.rb
@@ -1,0 +1,5 @@
+class AddQuantityToLineItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :line_items, :quantity, :integer
+  end
+end

--- a/db/migrate/20201122224833_add_quantity_to_line_items.rb
+++ b/db/migrate/20201122224833_add_quantity_to_line_items.rb
@@ -1,5 +1,5 @@
 class AddQuantityToLineItems < ActiveRecord::Migration[6.0]
   def change
-    add_column :line_items, :quantity, :integer
+    add_column :line_items, :quantity, :integer, default: 1
   end
 end

--- a/db/migrate/20201209205803_combine_items_in_cart.rb
+++ b/db/migrate/20201209205803_combine_items_in_cart.rb
@@ -1,0 +1,39 @@
+class CombineItemsInCart < ActiveRecord::Migration[6.0]
+  def up
+    # replace multiple items for a single product in a cart with a
+    # single item
+    Cart.all.each do |cart|
+      # count the number of each product in the cart
+      sums = cart.line_items.group(:product_id).sum(:quantity)
+
+      sums.each do |product_id, quantity|
+        if quantity > 1
+          # remove individual items
+          cart.line_items.where(product_id: product_id).delete_all
+
+          # replace with a single item
+          item = cart.line_items.build(product_id: product_id)
+          item.quantity = quantity
+          item.save!
+        end
+      end
+    end
+  end
+
+  def down
+    # split items with quantity>1 into multiple items
+    LineItem.where("quantity>1").each do |line_item|
+      # add individual items
+      line_item.quantity.times do
+        LineItem.create(
+          cart_id: line_item.cart_id,
+          product_id: line_item.product_id,
+          quantity: 1
+        )
+      end
+
+      # reemove original item
+      line_item.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_22_224833) do
+ActiveRecord::Schema.define(version: 2020_12_09_205803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_163254) do
+ActiveRecord::Schema.define(version: 2020_11_22_224833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2020_11_20_163254) do
     t.bigint "cart_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "quantity", default: 1
     t.index ["cart_id"], name: "index_line_items_on_cart_id"
     t.index ["product_id"], name: "index_line_items_on_product_id"
   end

--- a/test/controllers/line_items_controller_test.rb
+++ b/test/controllers/line_items_controller_test.rb
@@ -25,7 +25,7 @@ class LineItemsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_select "h2", "Your Pragmatic Cart"
-    assert_select "li", "1 ​​× Programming Ruby 1.9"
+    assert_select "li", "1 \u00D7 Programming Ruby 1.9"
   end
 
   test "should show line_item" do

--- a/test/controllers/line_items_controller_test.rb
+++ b/test/controllers/line_items_controller_test.rb
@@ -25,7 +25,7 @@ class LineItemsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_select "h2", "Your Pragmatic Cart"
-    assert_select "li", "Programming Ruby 1.9"
+    assert_select "li", "1 \u00D7 Programming Ruby 1.9"
   end
 
   test "should show line_item" do

--- a/test/controllers/line_items_controller_test.rb
+++ b/test/controllers/line_items_controller_test.rb
@@ -25,7 +25,7 @@ class LineItemsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_select "h2", "Your Pragmatic Cart"
-    assert_select "li", "1 \u00D7 Programming Ruby 1.9"
+    assert_select "li", "1 ​​× Programming Ruby 1.9"
   end
 
   test "should show line_item" do


### PR DESCRIPTION
## Story:
This PR adds the `quantity` attribute to `line_item` in the database via a migration, it also adds the method `add_product` that's used instead of `line_items.build` to add items to the cart.  `add_product` checks if there's already a `line_item` for the product and if so, increments the `line_item` by one, if not, it creates a new `line_item` for the product in the session cart. It also creates and uses a migration to update the existing carts in the database to combine line items for the same product. It also changes the formatting on the cart show view to show the quantity of an item that's in the session cart per line item. (Does that make sense?)

## Changes:
  - added a column to `line_items` in the database: quantity and set it's default value to `1`
  - changed behaviour when customer adds product to cart from adding a new line item to checking if the product is in the cart and adding 1 to the quantity if found. via `add_product` method
  - created a migration to consolidate line items within carts by product id
  - updated tests

## Lessons Learned: 
  - used a migration to change content of the database rather than the database structure
  -  `bin/rails db:migrate:status` - generates a handy list of the migrations that have been run and their current states.
  - kind of run to run and roll back the migration and refresh the cart.
  - the change to the test talked about using the unicode `\u00D7` for the `×` adding this line to the test was killing me, it wouldn't work and I couldn't figure it out. I finally downloaded their source code and copied and pasted that.  Then went back to really look at it.  I would've figured this out MUCH FASTER using `git diff` ultimately, it was something weird copying and pasting from the book text. dinnae do that is what I learned. if you do - check `git diff`, it'll show you what's actually "written" on the page - the real differences between the version that works and the one that doesn't. what a nightmare. 
![image](https://user-images.githubusercontent.com/41622204/102667350-07a87800-4181-11eb-919e-fe5b6ed1ee7e.png)
![image](https://user-images.githubusercontent.com/41622204/102667396-273fa080-4181-11eb-8cfb-742ba0c7beaf.png)
 

## Questions:
  -

## Answers:

## Resources:

## Screenshots: 
[If you made some visual changes to the application please upload screenshots here, or remove this section]